### PR TITLE
Add default ImGui layout configuration

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -1,0 +1,20 @@
+[Window][Debug##Default]
+Pos=60,60
+Size=400,400
+
+[Window][Simulation Controls]
+Pos=60,60
+Size=257,318
+
+[Window][Rendering Options]
+Pos=224,433
+Size=137,77
+
+[Window][Debug Info]
+Pos=434,13
+Size=247,137
+
+[Window][Dynamics Data]
+Pos=60,690
+Size=627,444
+


### PR DESCRIPTION
Introduce an initial `imgui.ini` file with predefined window positions and sizes for various UI elements. This serves as a default layout to enhance usability and ensure consistent interface behavior.